### PR TITLE
Fix Ctrl+C handling to prevent help message display

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -259,6 +259,17 @@ func init() {
 }
 
 func executeRoot() {
+	// Set up a channel to receive OS signals
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	// Start a goroutine to handle signals
+	go func() {
+		<-c
+		// Just exit silently with status 0 when Ctrl+C is pressed
+		os.Exit(0)
+	}()
+
 	if err := rootCmd.Execute(); err != nil {
 		color.Red("Error: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
This PR improves the Ctrl+C handling to ensure that help messages are never displayed when the user presses Ctrl+C to exit the application.

## Changes

- Added a top-level signal handler in the  function that immediately exits with status code 0 when Ctrl+C is pressed
- This ensures that even if the context cancellation doesn't propagate properly through all layers, the application will still exit gracefully without showing help messages

## Testing

- All tests are passing
- Manual testing confirms that Ctrl+C now properly exits the application without showing help messages