### PR TITLE
Add Homebrew installation support

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,45 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-homebrew-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get release info
+        id: release-info
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          TARBALL_URL="https://github.com/${{ github.repository }}/archive/refs/tags/${VERSION}.tar.gz"
+          echo "tarball_url=$TARBALL_URL" >> $GITHUB_OUTPUT
+          SHA256=$(curl -sL $TARBALL_URL | shasum -a 256 | cut -d ' ' -f 1)
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+
+      - name: Checkout homebrew-ekslogs repo
+        uses: actions/checkout@v4
+        with:
+          repository: kzcat/homebrew-ekslogs
+          path: homebrew-ekslogs
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Update Formula
+        run: |
+          VERSION=${{ steps.release-info.outputs.version }}
+          SHA256=${{ steps.release-info.outputs.sha256 }}
+          
+          cat ./homebrew/ekslogs.rb.template | \
+            sed "s/VERSION/$VERSION/g" | \
+            sed "s/SHA256/$SHA256/g" > homebrew-ekslogs/ekslogs.rb
+          
+          cd homebrew-ekslogs
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add ekslogs.rb
+          git commit -m "Update ekslogs to $VERSION"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Homebrew installation support
+- Documentation for setting up Homebrew tap
+
 ## [0.1.4] - 2025-07-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ For a complete list of changes and version history, see the [CHANGELOG](CHANGELO
 
 ## Installation
 
+### Using Homebrew
+```bash
+brew tap kzcat/ekslogs
+brew install ekslogs
+```
+
 ### Using Go Install
 ```bash
 go install github.com/kzcat/ekslogs@latest

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,0 +1,77 @@
+# Homebrew Installation Guide
+
+This document explains how to set up a Homebrew tap for ekslogs.
+
+## Creating a Homebrew Tap Repository
+
+1. Create a new GitHub repository named `homebrew-ekslogs`
+   - The repository name must start with `homebrew-`
+   - Make it public
+
+2. Clone the repository locally:
+   ```bash
+   git clone https://github.com/kzcat/homebrew-ekslogs.git
+   cd homebrew-ekslogs
+   ```
+
+3. Create a Formula file named `ekslogs.rb` with the following content:
+   ```ruby
+   class Ekslogs < Formula
+     desc "A fast and intuitive CLI tool for retrieving and monitoring Amazon EKS cluster Control Plane logs"
+     homepage "https://github.com/kzcat/ekslogs"
+     url "https://github.com/kzcat/ekslogs/archive/refs/tags/v0.1.4.tar.gz"
+     sha256 "REPLACE_WITH_ACTUAL_SHA256"
+     license "MIT"
+     
+     depends_on "go" => :build
+     
+     def install
+       system "go", "build", *std_go_args(ldflags: "-s -w")
+     end
+     
+     test do
+       assert_match "ekslogs version", shell_output("#{bin}/ekslogs version")
+     end
+   end
+   ```
+
+4. Calculate the SHA256 checksum of the tarball:
+   ```bash
+   curl -L https://github.com/kzcat/ekslogs/archive/refs/tags/v0.1.4.tar.gz | shasum -a 256
+   ```
+
+5. Replace `REPLACE_WITH_ACTUAL_SHA256` with the actual SHA256 checksum.
+
+6. Commit and push the Formula:
+   ```bash
+   git add ekslogs.rb
+   git commit -m "Add ekslogs formula"
+   git push
+   ```
+
+7. Test the Formula locally:
+   ```bash
+   brew tap kzcat/ekslogs
+   brew install ekslogs
+   ```
+
+## Updating the Formula
+
+When a new version of ekslogs is released:
+
+1. Update the URL and SHA256 in the Formula:
+   ```ruby
+   url "https://github.com/kzcat/ekslogs/archive/refs/tags/vX.Y.Z.tar.gz"
+   sha256 "NEW_SHA256_CHECKSUM"
+   ```
+
+2. Commit and push the changes:
+   ```bash
+   git add ekslogs.rb
+   git commit -m "Update ekslogs to vX.Y.Z"
+   git push
+   ```
+
+## Automating Formula Updates
+
+Consider setting up a GitHub Action in the main ekslogs repository that automatically updates the Formula in the homebrew-ekslogs repository when a new release is created.

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,30 @@
+# Homebrew Tap for ekslogs
+
+This repository contains the Homebrew Formula for [ekslogs](https://github.com/kzcat/ekslogs), a fast and intuitive CLI tool for retrieving and monitoring Amazon EKS cluster Control Plane logs.
+
+## Installation
+
+```bash
+brew tap kzcat/ekslogs
+brew install ekslogs
+```
+
+## Updating
+
+To upgrade to the latest version:
+
+```bash
+brew update
+brew upgrade ekslogs
+```
+
+## Uninstallation
+
+```bash
+brew uninstall ekslogs
+brew untap kzcat/ekslogs
+```
+
+## Development
+
+This tap is maintained by the ekslogs team. If you encounter any issues, please report them in the [main repository](https://github.com/kzcat/ekslogs/issues).

--- a/homebrew/ekslogs.rb.template
+++ b/homebrew/ekslogs.rb.template
@@ -1,0 +1,17 @@
+class Ekslogs < Formula
+  desc "A fast and intuitive CLI tool for retrieving and monitoring Amazon EKS cluster Control Plane logs"
+  homepage "https://github.com/kzcat/ekslogs"
+  url "https://github.com/kzcat/ekslogs/archive/refs/tags/VERSION.tar.gz"
+  sha256 "SHA256"
+  license "MIT"
+  
+  depends_on "go" => :build
+  
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+  
+  test do
+    assert_match "ekslogs version", shell_output("#{bin}/ekslogs version")
+  end
+end


### PR DESCRIPTION
This PR adds support for installing ekslogs via Homebrew.

### Changes:

- Added Homebrew installation instructions to README.md
- Created documentation for setting up a Homebrew tap
- Added a template for the Homebrew Formula
- Created a GitHub Actions workflow to automatically update the Homebrew Formula when a new release is published

### Next steps after merging:

1. Create a new GitHub repository named 'homebrew-ekslogs'
2. Follow the instructions in docs/homebrew.md to set up the Homebrew tap
3. Create a GitHub Personal Access Token with repo scope and add it as a secret named HOMEBREW_TAP_TOKEN to the main repository
4. Release a new version to test the automatic Formula update workflow