### PR TITLE
Add color support for message-only mode (-m option)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Enhanced color output for different log types
 - New `--color` option to control color output (auto, always, never)
 - Automatic color detection based on terminal or pipe output
+- Color support for message-only mode (`-m` option)
 
 ## [0.1.5] - 2025-07-20
 

--- a/pkg/log/color.go
+++ b/pkg/log/color.go
@@ -328,3 +328,211 @@ func getLevelColor(level string) *color.Color {
 		return color.New()
 	}
 }
+
+// ColorizeMessageOnly applies color formatting to just the message part based on log type
+func (lc *LogColorizer) ColorizeMessageOnly(message string, logType string, level string) string {
+	if !lc.config.ShouldUseColor() {
+		return message
+	}
+
+	// Apply color based on log type
+	switch logType {
+	case "api":
+		return lc.colorizeAPIMessage(message, level)
+	case "audit":
+		return lc.colorizeAuditMessage(message, level)
+	case "authenticator":
+		return lc.colorizeAuthenticatorMessage(message, level)
+	case "kcm":
+		return lc.colorizeControllerManagerMessage(message, level)
+	case "ccm":
+		return lc.colorizeCloudControllerManagerMessage(message, level)
+	case "scheduler":
+		return lc.colorizeSchedulerMessage(message, level)
+	default:
+		return lc.colorizeDefaultMessage(message, level)
+	}
+}
+
+// colorizeAPIMessage applies color formatting specific to API server messages
+func (lc *LogColorizer) colorizeAPIMessage(message string, level string) string {
+	// Highlight error messages
+	errorPattern := regexp.MustCompile(`(error|failed|failure|unable to|cannot|timeout)`)
+	message = errorPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgRed).Sprint(s)
+	})
+
+	// Highlight resource names
+	resourcePattern := regexp.MustCompile(`(pod|node|service|deployment|daemonset|statefulset|configmap|secret|namespace)/([a-zA-Z0-9-_.]+)`)
+	message = resourcePattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgCyan).Sprint(s)
+	})
+
+	// Highlight success messages
+	successPattern := regexp.MustCompile(`(success|successfully|created|updated|deleted)`)
+	message = successPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgGreen).Sprint(s)
+	})
+
+	return message
+}
+
+// colorizeAuditMessage applies color formatting specific to audit messages
+func (lc *LogColorizer) colorizeAuditMessage(message string, level string) string {
+	// For audit logs, try to parse the JSON and highlight specific fields
+	var auditData map[string]interface{}
+
+	if strings.HasPrefix(strings.TrimSpace(message), "{") {
+		err := json.Unmarshal([]byte(message), &auditData)
+		if err == nil {
+			// Format specific fields with colors
+			if verb, ok := auditData["verb"].(string); ok {
+				verbColor := color.New(color.FgMagenta).SprintFunc()
+				message = strings.Replace(message, fmt.Sprintf(`"verb":"%s"`, verb),
+					fmt.Sprintf(`"verb":"%s"`, verbColor(verb)), 1)
+			}
+
+			if uri, ok := auditData["requestURI"].(string); ok {
+				uriColor := color.New(color.FgGreen).SprintFunc()
+				message = strings.Replace(message, fmt.Sprintf(`"requestURI":"%s"`, uri),
+					fmt.Sprintf(`"requestURI":"%s"`, uriColor(uri)), 1)
+			}
+
+			// Highlight user information
+			if user, ok := auditData["user"].(map[string]interface{}); ok {
+				if username, ok := user["username"].(string); ok {
+					usernameColor := color.New(color.FgYellow).SprintFunc()
+					message = strings.Replace(message, fmt.Sprintf(`"username":"%s"`, username),
+						fmt.Sprintf(`"username":"%s"`, usernameColor(username)), 1)
+				}
+			}
+
+			// Highlight response status
+			if status, ok := auditData["responseStatus"].(map[string]interface{}); ok {
+				if code, ok := status["code"].(float64); ok {
+					codeStr := fmt.Sprintf("%.0f", code)
+					codeColor := color.New(color.FgGreen)
+					if code >= 400 {
+						codeColor = color.New(color.FgRed)
+					}
+					message = strings.Replace(message, fmt.Sprintf(`"code":%s`, codeStr),
+						fmt.Sprintf(`"code":%s`, codeColor.Sprint(codeStr)), 1)
+				}
+			}
+		}
+	}
+
+	return message
+}
+
+// colorizeAuthenticatorMessage applies color formatting specific to authenticator messages
+func (lc *LogColorizer) colorizeAuthenticatorMessage(message string, level string) string {
+	// Highlight ARNs
+	arnPattern := regexp.MustCompile(`arn:aws:[a-zA-Z0-9-]+:[a-zA-Z0-9-]*:[0-9]+:[a-zA-Z0-9-:/]+`)
+	message = arnPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgYellow).Sprint(s)
+	})
+
+	// Highlight access granted/denied
+	accessPattern := regexp.MustCompile(`access (granted|denied)`)
+	message = accessPattern.ReplaceAllStringFunc(message, func(match string) string {
+		if strings.Contains(match, "granted") {
+			return color.New(color.FgGreen).Sprint(match)
+		}
+		return color.New(color.FgRed).Sprint(match)
+	})
+
+	// Highlight usernames
+	usernamePattern := regexp.MustCompile(`username="([^"]+)"`)
+	message = usernamePattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgCyan).Sprint(s)
+	})
+
+	return message
+}
+
+// colorizeControllerManagerMessage applies color formatting specific to controller manager messages
+func (lc *LogColorizer) colorizeControllerManagerMessage(message string, level string) string {
+	// Highlight controller names
+	controllerPattern := regexp.MustCompile(`\b([a-zA-Z0-9-]+)_controller\b`)
+	message = controllerPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgMagenta).Sprint(s)
+	})
+
+	// Highlight resource names
+	resourcePattern := regexp.MustCompile(`(pod|node|service|deployment|daemonset|statefulset|configmap|secret|namespace)/([a-zA-Z0-9-_.]+)`)
+	message = resourcePattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgCyan).Sprint(s)
+	})
+
+	// Highlight error messages
+	errorPattern := regexp.MustCompile(`(error|failed|failure|unable to|cannot|timeout)`)
+	message = errorPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgRed).Sprint(s)
+	})
+
+	return message
+}
+
+// colorizeCloudControllerManagerMessage applies color formatting specific to cloud controller manager messages
+func (lc *LogColorizer) colorizeCloudControllerManagerMessage(message string, level string) string {
+	// Highlight AWS resource IDs
+	awsResourcePattern := regexp.MustCompile(`\b(vpc-|subnet-|sg-|i-|vol-|rtb-|igw-|nat-|eni-|eip-|acl-)[a-f0-9]+\b`)
+	message = awsResourcePattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgCyan).Sprint(s)
+	})
+
+	// Highlight controller names
+	controllerPattern := regexp.MustCompile(`\b([a-zA-Z0-9-]+)_controller\b`)
+	message = controllerPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgMagenta).Sprint(s)
+	})
+
+	// Highlight error messages
+	errorPattern := regexp.MustCompile(`(error|failed|failure|unable to|cannot|timeout)`)
+	message = errorPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgRed).Sprint(s)
+	})
+
+	return message
+}
+
+// colorizeSchedulerMessage applies color formatting specific to scheduler messages
+func (lc *LogColorizer) colorizeSchedulerMessage(message string, level string) string {
+	// Highlight scheduling related keywords
+	schedPattern := regexp.MustCompile(`\b(schedule|scheduling|scheduled|unschedulable|predicates|priorities|binding|bound)\b`)
+	message = schedPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgMagenta).Sprint(s)
+	})
+
+	// Highlight pod names
+	podPattern := regexp.MustCompile(`pod/([a-zA-Z0-9-_.]+)`)
+	message = podPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgCyan).Sprint(s)
+	})
+
+	// Highlight node names
+	nodePattern := regexp.MustCompile(`node/([a-zA-Z0-9-_.]+)`)
+	message = nodePattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgYellow).Sprint(s)
+	})
+
+	return message
+}
+
+// colorizeDefaultMessage applies default color formatting to messages
+func (lc *LogColorizer) colorizeDefaultMessage(message string, level string) string {
+	// Highlight error messages
+	errorPattern := regexp.MustCompile(`(error|failed|failure|unable to|cannot|timeout)`)
+	message = errorPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgRed).Sprint(s)
+	})
+
+	// Highlight success messages
+	successPattern := regexp.MustCompile(`(success|successfully|created|updated|deleted)`)
+	message = successPattern.ReplaceAllStringFunc(message, func(s string) string {
+		return color.New(color.FgGreen).Sprint(s)
+	})
+
+	return message
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -194,15 +194,25 @@ func ExtractLogTypeFromStreamName(streamName string) string {
 }
 
 func PrintLog(log LogEntry, messageOnly bool, colorConfig *ColorConfig) {
+	// Use the colorizer
+	colorizer := NewLogColorizer(colorConfig)
+
 	if messageOnly {
-		fmt.Println(log.Message)
+		// Apply color to message only if colors are enabled
+		if colorConfig.ShouldUseColor() {
+			// Get the log type to determine which colorization to apply
+			logType := NormalizeLogType(ExtractLogTypeFromStreamName(log.LogStream))
+			coloredMessage := colorizer.ColorizeMessageOnly(log.Message, logType, log.Level)
+			fmt.Println(coloredMessage)
+		} else {
+			fmt.Println(log.Message)
+		}
 		// Flush stdout to ensure immediate output when piped
 		_ = os.Stdout.Sync()
 		return
 	}
 
-	// Use the new colorizer
-	colorizer := NewLogColorizer(colorConfig)
+	// Full log output with colors
 	fmt.Println(colorizer.ColorizeLog(log))
 
 	// Flush stdout to ensure immediate output when piped


### PR DESCRIPTION
This PR adds color support for message-only mode (-m option).

### Changes:

- Modified the PrintLog function to apply color formatting even when using message-only mode
- Added ColorizeMessageOnly method to the LogColorizer to handle message-only colorization
- Added specific colorization methods for each log type's message content
- Updated CHANGELOG.md to document the new feature

Previously, when using the  option, the output was plain text without any color formatting. With this change, the message content will be colorized based on the log type, making it easier to identify important information even in message-only mode.