### PR TITLE
Fix JSON parsing for audit logs to properly highlight error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Enhanced error message highlighting in audit logs
 - Bold formatting for error messages, status codes, and failure states
 - Added highlighting for error reasons and status fields
+- Fixed JSON parsing for audit logs to properly highlight escaped error messages
 
 ## [0.1.5] - 2025-07-20
 


### PR DESCRIPTION
This PR fixes the JSON parsing for audit logs to properly highlight error messages, especially when they contain escaped characters.

### Changes:

- Completely rewrote the audit log colorization to use proper JSON parsing
- Added new methods to handle JSON colorization while preserving ANSI color codes
- Implemented a custom JSON formatter that preserves color codes
- Updated the message-only mode to use the same JSON colorization
- Updated CHANGELOG.md to document the fix

### Example:

For audit logs with error messages like:


The error message will now be properly highlighted with bold red color, even with the escaped quotes.