### PR TITLE
Fix Homebrew formula to include version information in build

### DIFF
--- a/homebrew/ekslogs.rb.template
+++ b/homebrew/ekslogs.rb.template
@@ -8,7 +8,13 @@ class Ekslogs < Formula
   depends_on "go" => :build
   
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    ldflags = %W[
+      -s -w
+      -X github.com/kzcat/ekslogs/cmd.version=VERSION
+      -X github.com/kzcat/ekslogs/cmd.commit=homebrew-VERSION
+      -X github.com/kzcat/ekslogs/cmd.date=#{Time.now.utc.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
   
   test do


### PR DESCRIPTION
## Problem
When installing ekslogs via Homebrew, the `ekslogs version` command shows incorrect information:
```
ekslogs version dev
commit: none
built at: unknown
```

This happens because the Homebrew formula doesn't include the necessary ldflags to embed version information during the build process.

## Solution
This PR fixes the Homebrew formula template to include proper ldflags that embed:
- **Version**: The actual release version (e.g., v0.1.6)
- **Commit**: Homebrew build identifier (homebrew-VERSION)
- **Build Date**: Timestamp when the package was built

## Changes
- Modified `homebrew/ekslogs.rb.template` to include ldflags with version information
- Added proper Go build flags to embed version, commit, and date information
- Ensures consistency between different installation methods

## Testing
After this change, Homebrew users will see proper version information:
```
ekslogs version v0.1.6
commit: homebrew-v0.1.6
built at: 2025-07-28T13:45:00Z
```

## Impact
- Improves user experience by showing correct version information
- Helps with debugging and support by providing accurate build details
- Maintains consistency with other installation methods (go install, direct download)

This fix will be automatically applied to the Homebrew formula when the next release is published.